### PR TITLE
Use resource.AddWorkshop instead

### DIFF
--- a/lua/autorun/fin3.lua
+++ b/lua/autorun/fin3.lua
@@ -9,7 +9,7 @@ if SERVER then
     AddCSLuaFile("fin3/sh_fin3_globals.lua")
     AddCSLuaFile("fin3/sh_fin3_util.lua")
     AddCSLuaFile("fin3/sh_fin3_models.lua")
-    resource.AddFile("resource/localization/en/fin3.properties")
+    resource.AddWorkshop("3113528615")
 else
     include("fin3/cl_fin3_hud.lua")
 end


### PR DESCRIPTION
For servers that have `sv_allowdownload` and FastDL disabled, this is the only way to deliver content, but it also works for servers that use other content methods, so this is the "best" way to ship files in a setup like this 👍 
